### PR TITLE
Add city config menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -28,13 +28,28 @@
                     "confirm-create": "Confirm trade good creation. Name cannot be modified after.",
                     "cancel-create": "Cancel trade good creation",
                     "missing-goods": "No trade goods configured"
+                },
+                "cities-menu": {
+                    "name": "Configure cities",
+                    "label": "Cities",
+                    "hint": "Add and remove cities",
+                    "title": "Cities config",
+                    "create-city": "Create city",
+                    "delete-city": "Delete city",
+                    "confirm-create": "Confirm city creation. Name cannot be modified after.",
+                    "cancel-create": "Cancel city creation",
+                    "missing-cities": "No cities configured"
                 }
             }
         },
         "confirms": {
-            "delete-confirm": {
+            "delete-confirm-good": {
                 "title": "Delete trade good",
                 "content": "Are you sure you want to delete the trade good? This cannot be undone."
+            },
+            "delete-confirm-city": {
+                "title": "Delete city",
+                "content": "Are you sure you want to delete the city? This cannot be undone."
             }
         }
     }

--- a/languages/en.json
+++ b/languages/en.json
@@ -25,6 +25,7 @@
                     "name-title": "The name of the trade good",
                     "value-title": "The base value of the trade good as a whole number",
                     "create-good": "Create trade good",
+                    "delete-good": "Delete trade good",
                     "confirm-create": "Confirm trade good creation. Name cannot be modified after.",
                     "cancel-create": "Cancel trade good creation",
                     "missing-goods": "No trade goods configured"

--- a/module.json
+++ b/module.json
@@ -20,7 +20,8 @@
     ],
     "templates": [
         "templates/sas-goods-config.hbs",
-        "templates/sas-base-goods-config.hbs"
+        "templates/sas-base-goods-config.hbs",
+        "templates/sas-cities-config.hbs"
     ],
     "styles": [
         "styles/sas-trading.css"

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -813,6 +813,9 @@ class SasTradingCitiesConfig extends FormApplication {
                 this.deleteNewCity(newCityId)
                 this.render()
                 break
+            case 'cancel-create':
+                this.deleteNewCity(newCityId)
+                this.render()
         }
     }
 

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -763,8 +763,6 @@ class SasTradingCitiesConfig extends FormApplication {
 
     async _updateObject(event, formData) {
         const expandedData = foundry.utils.expandObject(formData)
-        SasTrading.log(false, 'form data', formData)
-        SasTrading.log(false, 'saving', { expandedData })
 
         // Because cities are immutable, there's no need to update the city data
 
@@ -784,7 +782,6 @@ class SasTradingCitiesConfig extends FormApplication {
     }
 
     async _handleButtonClick(event) {
-        SasTrading.log(false, 'button click event', event)
         const clickedElement = $(event.currentTarget)
         const action = clickedElement.data()?.action
         const cityName = clickedElement.parents('[data-city-name]')?.data()?.cityName

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -764,7 +764,7 @@ class SasTradingCitiesConfig extends FormApplication {
     async _updateObject(event, formData) {
         const expandedData = foundry.utils.expandObject(formData)
 
-        // Because cities are immutable, there's no need to update the city data
+        // Because cities are immutable, there's no need to update the existing city data
 
         // 1. Update new cities
         if (!expandedData.new || Object.keys(expandedData.new).length === 0) {

--- a/templates/sas-cities-config.hbs
+++ b/templates/sas-cities-config.hbs
@@ -1,0 +1,30 @@
+<form>
+    <ul class="sas-config flexcol">
+        {{#each cities as | city |}}
+            <li class="flexrow" data-city-name="{{this}}">
+                <p name="existing.{{this}}"><b>{{this}}</b></p>
+                <button type="button" title="{{localize "SAS-TRADING.settings.config.cities-menu.delete-city"}}" data-action="delete" class="flex0 sas-config-icon-button">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </li>
+        {{else}}
+            {{localize "SAS-TRADING.settings.config.cities-menu.missing-cities"}}
+        {{/each}}
+    </ul>
+    <ul class="sas-config flexcol">
+        {{#each newCities as | newCity |}}
+            <li class="flexrow" data-new-city-id="{{newCity.id}}">
+                <input type="text" value="{{newCity.name}}" name="new.{{newCity.id}}.name" data-dtype="String" />
+                <button type="button" title="{{localize "SAS-TRADING.settings.config.cities-menu.confirm-create"}}" data-action="confirm-create" class="flex0 sas-config-icon-button">
+                    <i class="fas fa-check"></i>
+                </button>
+                <button type="button" title="{{localize "SAS-TRADING.settings.config.cities-menu.cancel-create"}}" data-action="cancel-create" class="flex0 sas-config-icon-button">
+                    <i class="fas fa-times"></i>
+                </button>
+            </li>
+        {{/each}}
+    </ul>
+    <button type="button" data-action="create">
+        <i class="fas fa-plus"></i>{{localize "SAS-TRADING.settings.config.cities-menu.create-city"}}
+    </button>
+</form>


### PR DESCRIPTION
Add settings menu to configure cities

Reorder settings menus, so that the base goods and cities come before trade goods per city

Fix checks for empty data in `_updateObject` methods