### PR TITLE
Validate new base goods use number values

### DIFF
--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -654,7 +654,7 @@ class SasTradingBaseGoodConfig extends FormApplication {
         } else {
             // Sanitize form data here because updateBaseGoods doesn't
             // If any of the values aren't a number, drop them completely
-            const badValues = Object.entries(expandedData.existing).filter(([name, value]) => {
+            const badValues = Object.entries(expandedData.existing).filter(([_, value]) => {
                 return typeof value !== 'number'
             })
             if (badValues.length > 0) {
@@ -670,7 +670,6 @@ class SasTradingBaseGoodConfig extends FormApplication {
         if (!expandedData.new || Object.keys(expandedData.new).length === 0) {
             SasTrading.log(false, 'form data for new trade good base values was empty')
         } else {
-            // TODO: Sanitize new goods' values
             this.options.newGoods = foundry.utils.mergeObject(this.options.newGoods, expandedData.new)
         }
 
@@ -713,6 +712,10 @@ class SasTradingBaseGoodConfig extends FormApplication {
                 }
                 if (!newGood.value) {
                     SasTrading.log(false, 'cannot create trade good without a value', newGood)
+                    break
+                }
+                if (typeof newGood.value !== 'number') {
+                    SasTrading.log(false, 'trade good must have a number value', newGood)
                     break
                 }
                 await SasTradingBaseGoodData.createBaseGood(newGood.name, newGood.value)


### PR DESCRIPTION
Add backup validation for new base goods' values
* The input field already ensures only numbers are returned and if the input is not a number, the value is `null`. This was caught by the original check, but this second validation ensures if the input ever changes, only numbers can be used as values