### PR TITLE
Add trade good overview to trading menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -2,6 +2,7 @@
     "SAS-TRADING": {
         "demand": "Demand",
         "scarcity": "Supply",
+        "good": "Trade good",
         "name": "Name",
         "value": "Value",
         "settings": {
@@ -43,6 +44,12 @@
                 }
             }
         },
+        "trade-menu": {
+            "overview": {
+                "title": "Swords & Sandals trading menu",
+                "select-city": "Select city: "
+            }
+        },
         "confirms": {
             "delete-confirm-good": {
                 "title": "Delete trade good",
@@ -51,6 +58,11 @@
             "delete-confirm-city": {
                 "title": "Delete city",
                 "content": "Are you sure you want to delete the city? This cannot be undone."
+            }
+        },
+        "controls": {
+            "tools": {
+                "tool-button": "Open Swords & Sandals trading menu"
             }
         }
     }

--- a/languages/en.json
+++ b/languages/en.json
@@ -47,7 +47,8 @@
         "trade-menu": {
             "overview": {
                 "title": "Swords & Sandals trading menu",
-                "select-city": "Select city: "
+                "select-city": "Select city:",
+                "missing-goods": "No trade goods configured for this city. Configure them in the module's settings first."
             }
         },
         "confirms": {

--- a/module.json
+++ b/module.json
@@ -21,7 +21,8 @@
     "templates": [
         "templates/sas-goods-config.hbs",
         "templates/sas-base-goods-config.hbs",
-        "templates/sas-cities-config.hbs"
+        "templates/sas-cities-config.hbs",
+        "templates/sas-trading-menu.hbs"
     ],
     "styles": [
         "styles/sas-trading.css"

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -197,7 +197,7 @@ class SasTrading {
                 name: SasTrading.ID,
                 onClick: () => SasTrading.tradingMenu.render(true),
                 title: `${SasTrading.LANG}.controls.${SasTrading.CONTROLS.TOOLS}.${SasTrading.CONTROLS.TOOLS_BUTTON}`,
-                visible: true // TODO: This might need to be false, unsure how to make it GM only at the moment
+                visible: true
             }
             noteButton.tools.push(tradingToolButton)
         })

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -61,7 +61,8 @@ class SasTrading {
     static TEMPLATES = {
         CONFIG_GOODS: `modules/${this.ID}/templates/sas-goods-config.hbs`,
         CONFIG_BASE: `modules/${this.ID}/templates/sas-base-goods-config.hbs`,
-        CONFIG_CITIES: `modules/${this.ID}/templates/sas-cities-config.hbs` 
+        CONFIG_CITIES: `modules/${this.ID}/templates/sas-cities-config.hbs`,
+        MENU: `modules/${this.ID}/templates/sas-trading-menu.hbs`
     }
     static SETTINGS = {
         GOODS: 'goods',           // see {SasGoods}
@@ -73,6 +74,15 @@ class SasTrading {
         CONFIG_BASE: 'base-goods-menu',
         CONFIG_CITIES: 'cities-menu'
     }
+    static CONTROLS = {
+        TOOLS: 'tools',
+        TOOLS_BUTTON: 'tool-button'
+    }
+    static MENU = {
+        TRADE: 'trade-menu',
+        TRADE_OVERVIEW: 'overview'
+    }
+    static GM_ROLE = 4
 
     /**
      * log to console prefixed with ID.
@@ -168,6 +178,29 @@ class SasTrading {
 
     static initialize() {
         this.registerSettings()
+        this.tradingMenu = new SasTradingMenu()
+        
+        // Set up the tool button to open the trading menu
+        Hooks.on('getSceneControlButtons', buttons => {
+            if (game.users.current.role !== SasTrading.GM_ROLE) {
+                return
+            }
+            const noteButtons = buttons.filter(button => button.name === 'notes')
+            if (!noteButtons || noteButtons.length === 0) {
+                SasTrading.log(false, 'could not find the notes control button')
+                return
+            }
+            const noteButton = noteButtons[0]
+            const tradingToolButton = {
+                button: true,
+                icon: "fa-solid fa-usd",
+                name: SasTrading.ID,
+                onClick: () => SasTrading.tradingMenu.render(true),
+                title: `${SasTrading.LANG}.controls.${SasTrading.CONTROLS.TOOLS}.${SasTrading.CONTROLS.TOOLS_BUTTON}`,
+                visible: true // TODO: This might need to be false, unsure how to make it GM only at the moment
+            }
+            noteButton.tools.push(tradingToolButton)
+        })
     }
 }
 
@@ -828,6 +861,46 @@ class SasTradingCitiesConfig extends FormApplication {
      */
     deleteNewCity(newCityId) {
         this.options.newCities = foundry.utils.mergeObject(this.options.newCities, {[`-=${newCityId}`]: null}, {performDeletions: true})
+    }
+}
+
+class SasTradingMenu extends FormApplication {
+    static get defaultOptions() {
+        const defaults = super.defaultOptions
+        const overrides = {
+            height: 'auto',
+            width: '600',
+            id: 'sas-trading-menu',
+            title: SasTrading.localize(`${SasTrading.LANG}.${SasTrading.MENU.TRADE}.${SasTrading.MENU.TRADE_OVERVIEW}.title`),
+            template: SasTrading.TEMPLATES.MENU,
+            closeOnSubmit: false,
+            submitOnChange: true,
+            resizable: true,
+            selectedCity: SasTradingCitiesData.allCitiesSorted[0],
+        }
+        const mergedOptions = foundry.utils.mergeObject(defaults, overrides)
+
+        return mergedOptions
+    }
+
+    getData(options) {
+        const goodsByCity = SasTradingGoodData.goodsByCity[options.selectedCity] || {}
+        SasTrading.log(false, 'goods', goodsByCity, 'for city', options.selectedCity)
+        return {
+            goodsByCity: goodsByCity,
+            cities: SasTradingCitiesData.allCitiesSorted,
+            selectedCity: options.selectedCity
+        }
+    }
+
+    async _updateObject(event, formData) {
+        const expandedData = foundry.utils.expandObject(formData)
+        SasTrading.log(false, 'saving', expandedData)
+
+        // Update selected city
+        this.options.selectedCity = expandedData.selectedCity
+
+        this.render()
     }
 }
 

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -25,3 +25,13 @@
     box-shadow: none;
     text-shadow: 0 0 5px red;
 }
+
+.sas-menu {
+    padding: 0;
+    margin-top: 0;
+    gap: 1em;
+}
+
+.sas-menu-overview-table-data {
+    text-align: center;
+}

--- a/templates/sas-goods-config.hbs
+++ b/templates/sas-goods-config.hbs
@@ -1,5 +1,5 @@
 <form>
-    <select id="cities", name="selectedCity">
+    <select id="cities" name="selectedCity">
         {{#each cities}}
             <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
                 {{this}}

--- a/templates/sas-trading-menu.hbs
+++ b/templates/sas-trading-menu.hbs
@@ -1,0 +1,29 @@
+<form>
+    <div class="flexcol">
+        <div class="flexrow">
+            <p class="flex1">{{localize "SAS-TRADING.trade-menu.overview.select-city"}}</p>
+            <select class="flex1" id="cities" name="selectedCity">
+                {{#each cities}}
+                    <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
+                        {{this}}
+                    </option>
+                {{/each}}
+            </select>
+            <div class="flex3"></div>
+        </div>
+    </div>
+    <table>
+        <tr>
+            <th>{{localize "SAS-TRADING.good"}}</th>
+            <th>{{localize "SAS-TRADING.demand"}}</th>
+            <th>{{localize "SAS-TRADING.scarcity"}}</th>
+        </tr>
+        {{#each goodsByCity as | good | }}
+            <tr>
+                <td class="sas-menu-overview-table-data">{{good.name}}</td>
+                <td class="sas-menu-overview-table-data">{{good.demand}}</td>
+                <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
+            </tr>
+        {{/each}}
+    </table>
+</form>

--- a/templates/sas-trading-menu.hbs
+++ b/templates/sas-trading-menu.hbs
@@ -24,6 +24,12 @@
                 <td class="sas-menu-overview-table-data">{{good.demand}}</td>
                 <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
             </tr>
+        {{else}}
+            <tr>
+                <td colspan="3" class="sas-menu-overview-table-data">
+                    {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
+                </td> 
+            </tr>
         {{/each}}
     </table>
 </form>


### PR DESCRIPTION
Add the `FormApplication` subclass for the trading menu. Right now it just has an overview of trade goods by city. It will eventually be extended to include the buy/sell, gather information, and assessment pages.

Add a button to the notes `SceneControl` that opens the trading menu.