### PR TITLE
Add trade good counts to configs and menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -5,6 +5,8 @@
         "good": "Trade good",
         "name": "Name",
         "value": "Value",
+        "select-city": "Select city:",
+        "total-goods": "Total goods:",
         "settings": {
             "config": {
                 "goods-menu": {
@@ -47,7 +49,6 @@
         "trade-menu": {
             "overview": {
                 "title": "Swords & Sandals trading menu",
-                "select-city": "Select city:",
                 "missing-goods": "No trade goods configured for this city. Configure them in the module's settings first."
             }
         },

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -555,8 +555,10 @@ class SasTradingGoodConfig extends FormApplication {
 
     getData(options) {
         const goodsByCity = SasTradingGoodData.goodsByCity[options.selectedCity] || {}
+        const numGoods = Object.keys(goodsByCity).length
         return {
             goodsByCity: goodsByCity,
+            numGoods: numGoods,
             cities: SasTradingCitiesData.allCities,
             selectedCity: options.selectedCity,
             demands: Object.values(SasTradingGoodData.demand),
@@ -672,8 +674,10 @@ class SasTradingBaseGoodConfig extends FormApplication {
     }
 
     getData(options) {
+        const baseGoods = SasTradingBaseGoodData.allBaseGoodsList
         return {
-            baseGoods: SasTradingBaseGoodData.allBaseGoodsList,
+            baseGoods: baseGoods,
+            numBaseGoods: baseGoods.length,
             newGoods: options.newGoods
         }
     }
@@ -885,9 +889,11 @@ class SasTradingMenu extends FormApplication {
 
     getData(options) {
         const goodsByCity = SasTradingGoodData.goodsByCity[options.selectedCity] || {}
+        const numGoods = Object.keys(goodsByCity).length
         SasTrading.log(false, 'goods', goodsByCity, 'for city', options.selectedCity)
         return {
             goodsByCity: goodsByCity,
+            numGoods: numGoods,
             cities: SasTradingCitiesData.allCitiesSorted,
             selectedCity: options.selectedCity
         }

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -26,6 +26,10 @@
     text-shadow: 0 0 5px red;
 }
 
+.sas-config-header {
+    padding-bottom: 10px;
+}
+
 .sas-menu {
     padding: 0;
     margin-top: 0;

--- a/templates/sas-base-goods-config.hbs
+++ b/templates/sas-base-goods-config.hbs
@@ -1,4 +1,5 @@
 <form>
+    <p class="sas-config-header">{{localize "SAS-TRADING.total-goods"}} {{numBaseGoods}}</p>
     <ul class="sas-config flexcol">
         {{#each baseGoods as | baseGood |}}
             <li class="flexrow" data-base-good-name="{{baseGood.name}}">

--- a/templates/sas-goods-config.hbs
+++ b/templates/sas-goods-config.hbs
@@ -1,11 +1,18 @@
 <form>
-    <select id="cities" name="selectedCity">
-        {{#each cities}}
-            <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
-                {{this}}
-            </option>
-        {{/each}}
-    </select>
+    <div class="flexcol sas-config-header">
+        <div class="flexrow">
+            <p class="flex1">{{localize "SAS-TRADING.select-city"}}</p>
+            <select id="cities" name="selectedCity">
+                {{#each cities}}
+                    <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
+                        {{this}}
+                    </option>
+                {{/each}}
+            </select>
+            <div class="flex2"></div>
+            <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
+        </div>
+    </div>
     <ul class="sas-config flexcol">
         {{#each goodsByCity as | good |}}
             <li class="flexrow" data-good-id="{{good.id}}">

--- a/templates/sas-trading-menu.hbs
+++ b/templates/sas-trading-menu.hbs
@@ -1,7 +1,7 @@
 <form>
     <div class="flexcol">
         <div class="flexrow">
-            <p class="flex1">{{localize "SAS-TRADING.trade-menu.overview.select-city"}}</p>
+            <p class="flex1">{{localize "SAS-TRADING.select-city"}}</p>
             <select class="flex1" id="cities" name="selectedCity">
                 {{#each cities}}
                     <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
@@ -9,7 +9,8 @@
                     </option>
                 {{/each}}
             </select>
-            <div class="flex3"></div>
+            <div class="flex2"></div>
+            <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
         </div>
     </div>
     <table>


### PR DESCRIPTION
Add trade good counts to settings configs and trading menu. Hoping this makes it easier to validate each city has the right number of trade goods at a quick glance.