### PR TITLE
Add gather rumors tab to trading menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -56,7 +56,13 @@
             },
             "gather-info": {
                 "tab-title": "Gather rumors",
-                "roll-accuracy": "Roll rumor accuracy"
+                "roll-accuracy": "Roll rumor accuracy",
+                "results": {
+                    "title": "Gather rumors results",
+                    "content-success": "The rumors were accurate",
+                    "content-failure": "The rumors were innaccurate",
+                    "label": "Neat"
+                }
             }
         },
         "confirms": {

--- a/languages/en.json
+++ b/languages/en.json
@@ -5,6 +5,7 @@
         "good": "Trade good",
         "name": "Name",
         "value": "Value",
+        "select-good": "Select good:",
         "select-city": "Select city:",
         "total-goods": "Total goods:",
         "settings": {
@@ -47,9 +48,15 @@
             }
         },
         "trade-menu": {
+            "title": "Swords & Sandals trading menu",
+            "diplomacy-roll": "Diplomacy roll:",
             "overview": {
-                "title": "Swords & Sandals trading menu",
+                "tab-title": "Overview",
                 "missing-goods": "No trade goods configured for this city. Configure them in the module's settings first."
+            },
+            "gather-info": {
+                "tab-title": "Gather rumors",
+                "roll-accuracy": "Roll rumor accuracy"
             }
         },
         "confirms": {

--- a/module.json
+++ b/module.json
@@ -22,7 +22,9 @@
         "templates/sas-goods-config.hbs",
         "templates/sas-base-goods-config.hbs",
         "templates/sas-cities-config.hbs",
-        "templates/sas-trading-menu.hbs"
+        "templates/sas-trading-menu.hbs",
+        "templates/sas-trading-menu-overview.hbs",
+        "templates/sas-trading-menu-gather-info.hbs"
     ],
     "styles": [
         "styles/sas-trading.css"

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -893,9 +893,9 @@ class SasTradingMenu extends FormApplication {
     static get defaultOptions() {
         const defaults = super.defaultOptions
 
-        
         const selectedCity = SasTradingCitiesData.allCitiesSorted[0]
-        const selectedGood = selectedCity ? Object.keys(SasTradingGoodData.goodsByCity[selectedCity])[0] : undefined
+        const goodsByCity = SasTradingGoodData.goodsByCity[selectedCity]
+        const selectedGood = goodsByCity ? Object.keys(goodsByCity)[0] : ""
 
         const overrides = {
             height: 'auto',

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -181,11 +181,11 @@ class SasTrading {
         return game.i18n.localize(languageKey)
     }
 
-    static async initialize() {
+    static initialize() {
         this.registerSettings()
         this.tradingMenu = new SasTradingMenu()
         
-        // Handlebards partials need to be loaded in ahead of time to
+        // Handlebars partials need to be loaded in ahead of time to
         //   1. Tell foundry to load them
         //   2. Register them as partials with Handlebars
         loadTemplates([
@@ -942,13 +942,12 @@ class SasTradingMenu extends FormApplication {
         goodNames.forEach(name => {
             goodsByCity[name].value = baseGoods[name]
         })
-        const numGoods = goodNames.length
         SasTrading.log(false, 'goods', goodsByCity, 'for city', options.selectedCity)
         return {
             tabs: options.tabData,
             goodsByCity: goodsByCity,
             goodNames: goodNames,
-            numGoods: numGoods,
+            numGoods: goodNames.length,
             cities: SasTradingCitiesData.allCitiesSorted,
             selectedCity: options.selectedCity,
             selectedGood: options.selectedGood,

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -937,7 +937,11 @@ class SasTradingMenu extends FormApplication {
 
     getData(options) {
         const goodsByCity = SasTradingGoodData.goodsByCity[options.selectedCity] || {}
+        const baseGoods = SasTradingBaseGoodData.allBaseGoods
         const goodNames = Object.keys(goodsByCity)
+        goodNames.forEach(name => {
+            goodsByCity[name].value = baseGoods[name]
+        })
         const numGoods = goodNames.length
         SasTrading.log(false, 'goods', goodsByCity, 'for city', options.selectedCity)
         return {

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -1,0 +1,32 @@
+<div class="flexcol">
+    <div class="flexrow">
+        <p>{{localize "SAS-TRADING.select-city"}}</p>
+        <select id="gather-info-cities" name="gatherInfo.selectedCity">
+            {{#each cities as | cities |}}
+                <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
+                    {{this}}
+                </option>
+            {{/each}}
+        </select>
+        <div class="flex2"></div>
+    </div>
+    <div class="flexrow">
+        <p>{{localize "SAS-TRADING.select-good"}}</p>
+        <select id="gather-info-goods" name="gatherInfo.selectedGood">
+            {{#each goodNames as | goodName |}}
+                <option value="{{this}}" {{#if (eq ../selectedGood this)}}selected{{/if}}>
+                    {{this}}
+                </option>
+            {{/each}}
+        </select>
+        <div class="flex2"></div>
+    </div>
+    <div class="flexrow">
+        <p>{{localize "SAS-TRADING.trade-menu.diplomacy-roll"}}</p>
+        <input type="number" name="gatherInfo.diplomacyRoll" data-dtype="Number" value="{{diplomacyRoll}}"/>
+        <div class="flex2"></div>
+    </div>
+    <button type="button" data-action="gatherInfo-roll">
+        <i class="fas fa-eye"></i>{{localize "SAS-TRADING.trade-menu.gather-info.roll-accuracy"}}
+    </button>
+</div>

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -27,6 +27,6 @@
         <div class="flex2"></div>
     </div>
     <button type="button" data-action="gatherInfo-roll">
-        <i class="fas fa-eye"></i>{{localize "SAS-TRADING.trade-menu.gather-info.roll-accuracy"}}
+        <i class="fas fa-dice-d20"></i>{{localize "SAS-TRADING.trade-menu.gather-info.roll-accuracy"}}
     </button>
 </div>

--- a/templates/sas-trading-menu-overview.hbs
+++ b/templates/sas-trading-menu-overview.hbs
@@ -15,18 +15,20 @@
 <table>
     <tr>
         <th>{{localize "SAS-TRADING.good"}}</th>
+        <th>{{localize "SAS-TRADING.value"}}</th>
         <th>{{localize "SAS-TRADING.demand"}}</th>
         <th>{{localize "SAS-TRADING.scarcity"}}</th>
     </tr>
     {{#each goodsByCity as | good | }}
         <tr>
             <td class="sas-menu-overview-table-data">{{good.name}}</td>
+            <td class="sas-menu-overview-table-data">{{good.value}}</td>
             <td class="sas-menu-overview-table-data">{{good.demand}}</td>
             <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
         </tr>
     {{else}}
         <tr>
-            <td colspan="3" class="sas-menu-overview-table-data">
+            <td colspan="4" class="sas-menu-overview-table-data">
                 {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
             </td> 
         </tr>

--- a/templates/sas-trading-menu-overview.hbs
+++ b/templates/sas-trading-menu-overview.hbs
@@ -1,0 +1,34 @@
+<div class="flexcol">
+    <div class="flexrow">
+        <p class="flex1">{{localize "SAS-TRADING.select-city"}}</p>
+        <select class="flex1" id="overview-cities" name="overview.selectedCity">
+            {{#each cities}}
+                <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
+                    {{this}}
+                </option>
+            {{/each}}
+        </select>
+        <div class="flex2"></div>
+        <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
+    </div>
+</div>
+<table>
+    <tr>
+        <th>{{localize "SAS-TRADING.good"}}</th>
+        <th>{{localize "SAS-TRADING.demand"}}</th>
+        <th>{{localize "SAS-TRADING.scarcity"}}</th>
+    </tr>
+    {{#each goodsByCity as | good | }}
+        <tr>
+            <td class="sas-menu-overview-table-data">{{good.name}}</td>
+            <td class="sas-menu-overview-table-data">{{good.demand}}</td>
+            <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
+        </tr>
+    {{else}}
+        <tr>
+            <td colspan="3" class="sas-menu-overview-table-data">
+                {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
+            </td> 
+        </tr>
+    {{/each}}
+</table>

--- a/templates/sas-trading-menu.hbs
+++ b/templates/sas-trading-menu.hbs
@@ -1,36 +1,15 @@
 <form>
-    <div class="flexcol">
-        <div class="flexrow">
-            <p class="flex1">{{localize "SAS-TRADING.select-city"}}</p>
-            <select class="flex1" id="cities" name="selectedCity">
-                {{#each cities}}
-                    <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
-                        {{this}}
-                    </option>
-                {{/each}}
-            </select>
-            <div class="flex2"></div>
-            <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
-        </div>
-    </div>
-    <table>
-        <tr>
-            <th>{{localize "SAS-TRADING.good"}}</th>
-            <th>{{localize "SAS-TRADING.demand"}}</th>
-            <th>{{localize "SAS-TRADING.scarcity"}}</th>
-        </tr>
-        {{#each goodsByCity as | good | }}
-            <tr>
-                <td class="sas-menu-overview-table-data">{{good.name}}</td>
-                <td class="sas-menu-overview-table-data">{{good.demand}}</td>
-                <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
-            </tr>
-        {{else}}
-            <tr>
-                <td colspan="3" class="sas-menu-overview-table-data">
-                    {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
-                </td> 
-            </tr>
+    <nav class="tabs" data-group="primary-tabs">
+        {{#each tabs as | tab |}}
+            <a class="item" data-tab="{{tab.id}}">{{localize tab.title}}</a>
         {{/each}}
-    </table>
+    </nav>
+
+    <section class="content">
+        {{#each tabs as | tab |}}
+            <div class="tab" data-tab="{{tab.id}}" data-group="primary-tabs">
+                {{> (lookup . 'template') ../this}}
+            </div>
+        {{/each}}
+    </section>
 </form>


### PR DESCRIPTION
Change the trade menu to use tabs

The gather rumors tab allows GMs to automate the roll. Right now it just makes the roll and displays the result. Eventually, it will also display the chosen trade good for a little convenience.

Fix a bug where the trade menu wouldn't open if the first city didn't have any trade goods associated with it

Add trade good values to the overview tab in the trade menu