### PR TITLE
Add buy/sell tab to trading menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -50,6 +50,7 @@
         "trade-menu": {
             "title": "Swords & Sandals trading menu",
             "diplomacy-roll": "Diplomacy roll:",
+            "no-good-selected": "Select a good from the left to get started",
             "overview": {
                 "tab-title": "Overview",
                 "missing-goods": "No trade goods configured for this city. Configure them in the module's settings first."
@@ -63,6 +64,11 @@
                     "content-failure": "The rumors were innaccurate",
                     "label": "Neat"
                 }
+            },
+            "buy-sell": {
+                "tab-title": "Buy / Sell",
+                "buy": "Buy",
+                "sell": "Sell"
             }
         },
         "confirms": {

--- a/languages/en.json
+++ b/languages/en.json
@@ -68,7 +68,8 @@
             "buy-sell": {
                 "tab-title": "Buy / Sell",
                 "buy": "Buy",
-                "sell": "Sell"
+                "sell": "Sell",
+                "get-price": "Get price per unit"
             }
         },
         "confirms": {

--- a/module.json
+++ b/module.json
@@ -24,7 +24,8 @@
         "templates/sas-cities-config.hbs",
         "templates/sas-trading-menu.hbs",
         "templates/sas-trading-menu-overview.hbs",
-        "templates/sas-trading-menu-gather-info.hbs"
+        "templates/sas-trading-menu-gather-info.hbs",
+        "templates/sas-trading-menu-buy-sell.hbs"
     ],
     "styles": [
         "styles/sas-trading.css"

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -949,7 +949,7 @@ class SasTradingMenu extends FormApplication {
             selectedCity: selectedCity,
             selectedGoodName: selectedGoodName,
             selectedGood: selectedGood,
-            selectedBuy: false
+            selectedBuy: true
         }
         const mergedOptions = foundry.utils.mergeObject(defaults, overrides)
 
@@ -1067,21 +1067,6 @@ class SasTradingMenu extends FormApplication {
                     rejectClose: false,
                 })
                 break
-        }
-    }
-
-    /**
-     * emptyGood returns a single empty good so tables don't complain if a good
-     * hasn't been selected yet.
-     * @returns {SasGood} An empty good, with a value property appended.
-     */
-    static emptyGood() {
-        return {
-            id: "",
-            name: "",
-            demand: "",
-            scarcity: "",
-            value: ""
         }
     }
 }

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -209,7 +209,7 @@ class SasTrading {
             const noteButton = noteButtons[0]
             const tradingToolButton = {
                 button: true,
-                icon: "fa-solid fa-usd",
+                icon: "fa-solid fa-sack-dollar",
                 name: SasTrading.ID,
                 onClick: () => SasTrading.tradingMenu.render(true),
                 title: `${SasTrading.LANG}.controls.${SasTrading.CONTROLS.TOOLS}.${SasTrading.CONTROLS.TOOLS_BUTTON}`,

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -60,3 +60,11 @@
     border-left: 1px solid #191813;
     border-top: 1px solid #4b4a44
 }
+
+.sas-menu-button {
+    margin-top: 10px;
+}
+
+.sas-menu-content {
+    margin-top: 10px;
+}

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -36,6 +36,27 @@
     gap: 1em;
 }
 
-.sas-menu-overview-table-data {
+.sas-menu-mini-table {
+    width: 90%;
+    margin-left: 6%;
+}
+
+.sas-menu-table-data {
     text-align: center;
+}
+
+.sas-menu-table-left-column {
+    width: 25%;
+    font-weight: bold;
+    border-right: 1px solid var(--color-border-light-tertiary);
+}
+
+.sas-menu-table-header {
+    border-bottom: 1px solid var(--color-border-light-tertiary);
+}
+
+.sas-menu-placeholder {
+    border-right: 1px solid #23221d;
+    border-left: 1px solid #191813;
+    border-top: 1px solid #4b4a44
 }

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -36,29 +36,23 @@
     gap: 1em;
 }
 
+.sas-menu-table-data {
+    text-align: center;
+}
+
 .sas-menu-mini-table {
     width: 90%;
     margin-left: 6%;
 }
 
-.sas-menu-table-data {
-    text-align: center;
-}
-
-.sas-menu-table-left-column {
+.sas-menu-mini-table-left-column {
     width: 25%;
     font-weight: bold;
     border-right: 1px solid var(--color-border-light-tertiary);
 }
 
-.sas-menu-table-header {
+.sas-menu-mini-table-header {
     border-bottom: 1px solid var(--color-border-light-tertiary);
-}
-
-.sas-menu-placeholder {
-    border-right: 1px solid #23221d;
-    border-left: 1px solid #191813;
-    border-top: 1px solid #4b4a44
 }
 
 .sas-menu-button {

--- a/templates/sas-trading-menu-buy-sell.hbs
+++ b/templates/sas-trading-menu-buy-sell.hbs
@@ -1,0 +1,65 @@
+<div class="flexcol">
+    <div class="flexrow">
+        <div class="flexcol">
+            <div class="flexrow">
+                <p>{{localize "SAS-TRADING.select-city"}}</p>
+                <select id="buy-sell-cities" name="buySell.selectedCity">
+                    {{#each cities as | cities |}}
+                        <option value="{{this}}" {{#if (eq ../selectedCity this)}}selected{{/if}}>
+                            {{this}}
+                        </option>
+                    {{/each}}
+                </select>
+            </div>
+            <div class="flexrow">
+                <p>{{localize "SAS-TRADING.select-good"}}</p>
+                <select id="buy-sell-goods" name="buySell.selectedGood">
+                    {{#each goodNames as | goodName |}}
+                        <option value="{{this}}" {{#if (eq ../selectedGoodName this)}}selected{{/if}}>
+                            {{this}}
+                        </option>
+                    {{/each}}
+                </select>
+            </div>
+            <div class="flexrow">
+                <p>{{localize "SAS-TRADING.trade-menu.diplomacy-roll"}}</p>
+                <input type="number" name="buySell.diplomacyRoll" data-dtype="Number" value="{{diplomacyRoll}}"/>
+            </div>
+            <div class="flexrow">
+                <input type="radio" id="buy-sell-buy" name="buySell.choice" value="buy" {{#if selectedBuy}}selected{{/if}} />
+                <label for="buy-sell-buy">{{localize "SAS-TRADING.trade-menu.buy-sell.buy"}}</label>
+                <input type="radio" id="buy-sell-sell" name="buySell.choice" value="sell" {{#unless selectedBuy}}selected{{/unless}} />
+                <label for="buy-sell-sell">{{localize "SAS-TRADING.trade-menu.buy-sell.sell"}}</label>
+            </div>
+        </div>
+        <div class="flexcol">
+            <table class="sas-menu-mini-table">
+                {{#if selectedGood}}
+                    <tr>
+                        <th class="sas-menu-table-left-column sas-menu-table-header"></th>
+                        <th class="sas-menu-table-header">{{selectedGood.name}}</th>
+                    </tr>
+                    <tr>
+                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.value"}}</td>
+                        <td class="sas-menu-table-data">{{selectedGood.value}}</td>
+                    </tr>
+                    <tr>
+                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.demand"}}</td>
+                        <td class="sas-menu-table-data">{{selectedGood.demand}}</td>
+                    </tr>
+                    <tr>
+                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.scarcity"}}</td>
+                        <td class="sas-menu-table-data">{{selectedGood.scarcity}}</td>
+                    </tr>
+                {{else}}
+                    <tr>
+                        <th>{{localize "SAS-TRADING.good"}}</th>
+                    </tr>
+                    <tr>
+                        <td class="sas-menu-table-data">{{localize "SAS-TRADING.trade-menu.no-good-selected"}}</td>
+                    </tr>
+                {{/if}}
+            </table>
+        </div>
+    </div>
+</div>

--- a/templates/sas-trading-menu-buy-sell.hbs
+++ b/templates/sas-trading-menu-buy-sell.hbs
@@ -1,4 +1,4 @@
-<div class="flexcol">
+<div class="flexcol sas-menu-content">
     <div class="flexrow">
         <div class="flexcol">
             <div class="flexrow">
@@ -26,9 +26,9 @@
                 <input type="number" name="buySell.diplomacyRoll" data-dtype="Number" value="{{diplomacyRoll}}"/>
             </div>
             <div class="flexrow">
-                <input type="radio" id="buy-sell-buy" name="buySell.choice" value="buy" {{#if selectedBuy}}selected{{/if}} />
+                <input type="radio" id="buy-sell-buy" name="buySell.choice" value="buy" {{#if selectedBuy}}checked{{/if}} />
                 <label for="buy-sell-buy">{{localize "SAS-TRADING.trade-menu.buy-sell.buy"}}</label>
-                <input type="radio" id="buy-sell-sell" name="buySell.choice" value="sell" {{#unless selectedBuy}}selected{{/unless}} />
+                <input type="radio" id="buy-sell-sell" name="buySell.choice" value="sell" {{#unless selectedBuy}}checked{{/unless}} />
                 <label for="buy-sell-sell">{{localize "SAS-TRADING.trade-menu.buy-sell.sell"}}</label>
             </div>
         </div>
@@ -62,4 +62,7 @@
             </table>
         </div>
     </div>
+    <button type="button" class="sas-menu-button" data-action="buySell-getPrice">
+        <i class="fa-solid fa-coins"></i>{{localize "SAS-TRADING.trade-menu.buy-sell.get-price"}}
+    </button>
 </div>

--- a/templates/sas-trading-menu-buy-sell.hbs
+++ b/templates/sas-trading-menu-buy-sell.hbs
@@ -36,19 +36,19 @@
             <table class="sas-menu-mini-table">
                 {{#if selectedGood}}
                     <tr>
-                        <th class="sas-menu-table-left-column sas-menu-table-header"></th>
-                        <th class="sas-menu-table-header">{{selectedGood.name}}</th>
+                        <th class="sas-menu-mini-table-left-column sas-menu-mini-table-header"></th>
+                        <th class="sas-menu-mini-table-header">{{selectedGood.name}}</th>
                     </tr>
                     <tr>
-                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.value"}}</td>
+                        <td class="sas-menu-mini-table-left-column">{{localize "SAS-TRADING.value"}}</td>
                         <td class="sas-menu-table-data">{{selectedGood.value}}</td>
                     </tr>
                     <tr>
-                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.demand"}}</td>
+                        <td class="sas-menu-mini-table-left-column">{{localize "SAS-TRADING.demand"}}</td>
                         <td class="sas-menu-table-data">{{selectedGood.demand}}</td>
                     </tr>
                     <tr>
-                        <td class="sas-menu-table-left-column">{{localize "SAS-TRADING.scarcity"}}</td>
+                        <td class="sas-menu-mini-table-left-column">{{localize "SAS-TRADING.scarcity"}}</td>
                         <td class="sas-menu-table-data">{{selectedGood.scarcity}}</td>
                     </tr>
                 {{else}}

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -1,4 +1,4 @@
-<div class="flexcol">
+<div class="flexcol sas-menu-content">
     <div class="flexrow">
         <p>{{localize "SAS-TRADING.select-city"}}</p>
         <select id="gather-info-cities" name="gatherInfo.selectedCity">
@@ -26,7 +26,7 @@
         <input type="number" name="gatherInfo.diplomacyRoll" data-dtype="Number" value="{{diplomacyRoll}}"/>
         <div class="flex2"></div>
     </div>
-    <button type="button" data-action="gatherInfo-roll">
+    <button type="button" class="sas-menu-button" data-action="gatherInfo-roll">
         <i class="fas fa-dice-d20"></i>{{localize "SAS-TRADING.trade-menu.gather-info.roll-accuracy"}}
     </button>
 </div>

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -14,7 +14,7 @@
         <p>{{localize "SAS-TRADING.select-good"}}</p>
         <select id="gather-info-goods" name="gatherInfo.selectedGood">
             {{#each goodNames as | goodName |}}
-                <option value="{{this}}" {{#if (eq ../selectedGood this)}}selected{{/if}}>
+                <option value="{{this}}" {{#if (eq ../selectedGoodName this)}}selected{{/if}}>
                     {{this}}
                 </option>
             {{/each}}

--- a/templates/sas-trading-menu-overview.hbs
+++ b/templates/sas-trading-menu-overview.hbs
@@ -1,4 +1,4 @@
-<div class="flexcol">
+<div class="flexcol sas-menu-content">
     <div class="flexrow">
         <p class="flex1">{{localize "SAS-TRADING.select-city"}}</p>
         <select class="flex1" id="overview-cities" name="overview.selectedCity">

--- a/templates/sas-trading-menu-overview.hbs
+++ b/templates/sas-trading-menu-overview.hbs
@@ -21,14 +21,14 @@
     </tr>
     {{#each goodsByCity as | good | }}
         <tr>
-            <td class="sas-menu-overview-table-data">{{good.name}}</td>
-            <td class="sas-menu-overview-table-data">{{good.value}}</td>
-            <td class="sas-menu-overview-table-data">{{good.demand}}</td>
-            <td class="sas-menu-overview-table-data">{{good.scarcity}}</td>
+            <td class="sas-menu-table-data">{{good.name}}</td>
+            <td class="sas-menu-table-data">{{good.value}}</td>
+            <td class="sas-menu-table-data">{{good.demand}}</td>
+            <td class="sas-menu-table-data">{{good.scarcity}}</td>
         </tr>
     {{else}}
         <tr>
-            <td colspan="4" class="sas-menu-overview-table-data">
+            <td colspan="4" class="sas-menu-table-data">
                 {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
             </td> 
         </tr>


### PR DESCRIPTION
Add buy/sell tab to trading menu
* The buy/sell tab of the trading menu allows the GM to get the price of a good for buying or selling adjusted by the player's diplomacy roll.
* The buy/sell tab displays the selected item, which eventually be used in the gather info tab

Adjust formatting on overview and gather info tabs
