### PR TITLE
Add gather info roll results to trading menu

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -60,9 +60,15 @@
                 "roll-accuracy": "Roll rumor accuracy",
                 "results": {
                     "title": "Gather rumors results",
-                    "content-success": "The rumors were accurate",
-                    "content-failure": "The rumors were innaccurate",
-                    "label": "Neat"
+                    "content": "The rumors were",
+                    "success": "ACCURATE",
+                    "failure": "INNACCURATE",
+                    "accuracy-thresh": "Accuracy threshold:",
+                    "accuracy-roll": "Accuracy roll:",
+                    "accuracy-base-title": "Base DC for accuracy roll",
+                    "diplo-roll-title": "Diplomacy check result",
+                    "diplo-dc-title": "Diplomacy DC",
+                    "close": "Close results"
                 }
             },
             "buy-sell": {

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -972,7 +972,8 @@ class SasTradingMenu extends FormApplication {
             selectedGoodName: options.selectedGoodName,
             selectedGood: options.selectedGood,
             diplomacyRoll: options.diplomacyRoll,
-            selectedBuy: options.selectedBuy
+            selectedBuy: options.selectedBuy,
+            gatherInfoResult: options.gatherInfoResult
         }
     }
 
@@ -1035,16 +1036,20 @@ class SasTradingMenu extends FormApplication {
                 // See written rules for more info
                 const accuracyThresh = SasTradingMenu.BASE_GATHER_INFO_ACCURACY + (this.options.diplomacyRoll - SasTradingMenu.GATHER_INFO_DIPLO_DC)
                 const accurate = accuracyRoll.total <= accuracyThresh
-                const contentLocal = accurate ?
-                    `${SasTrading.LANG}.${SasTrading.MENU.TRADE}.${SasTrading.MENU.TRADE_GATHER_INFO}.results.content-success` :
-                    `${SasTrading.LANG}.${SasTrading.MENU.TRADE}.${SasTrading.MENU.TRADE_GATHER_INFO}.results.content-failure`
-                Dialog.prompt({
-                    title: SasTrading.localize(`${SasTrading.LANG}.${SasTrading.MENU.TRADE}.${SasTrading.MENU.TRADE_GATHER_INFO}.results.title`),
-                    content: SasTrading.localize(contentLocal),
-                    label: SasTrading.localize(`${SasTrading.LANG}.${SasTrading.MENU.TRADE}.${SasTrading.MENU.TRADE_GATHER_INFO}.results.label`),
-                    callback: (html) => SasTrading.log(false, 'accurate info:', accurate),
-                    rejectClose: false,
-                })
+                this.options.gatherInfoResult = {
+                    good: this.options.selectedGoodName,
+                    baseAccuracy: SasTradingMenu.BASE_GATHER_INFO_ACCURACY,
+                    diploDc: SasTradingMenu.GATHER_INFO_DIPLO_DC,
+                    diplomacyRoll: this.options.diplomacyRoll,
+                    accuracyThresh: accuracyThresh,
+                    accuracyRoll: accuracyRoll.total,
+                    accurate: accurate,
+                }
+                this.render()
+                break
+            case 'gatherInfo-close':
+                this.options.gatherInfoResult = undefined
+                this.render()
                 break
             case 'buySell-getPrice':
                 // The diplomacy roll is needed for the full evaluation, just break early if it's not in yet

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -62,3 +62,27 @@
 .sas-menu-content {
     margin-top: 10px;
 }
+
+.sas-menu-results {
+    margin-top: 10px;
+    border-top: 2px solid var(--color-underline-header);
+    border-bottom: 2px solid var(--color-underline-header);
+}
+
+.sas-menu-results > h2 {
+    text-align: center;
+}
+
+.sas-menu-results-gather-info {
+    text-align: center;
+}
+
+.sas-menu-results-gather-info-success {
+    font-weight: bold;
+    color: var(--color-level-success);
+}
+
+.sas-menu-results-gather-info-failure {
+    font-weight: bold;
+    color: var(--color-level-error);
+}

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -56,6 +56,61 @@
             </table>
         </div>
     </div>
+    {{#if gatherInfoResult}}
+    <div class="sas-menu-results">
+        <h2>
+            {{localize "SAS-TRADING.trade-menu.gather-info.results.title"}}
+        </h2>
+        <div class="flexrow">
+            <div class="flex3"></div>
+            <button type="button" title="{{localize "SAS-TRADING.trade-menu.gather-info.results.close"}}" data-action="gatherInfo-close" class="flex0 sas-config-icon-button">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <div class="flexrow">
+            <div class="flexcol sas-menu-results-gather-info">
+                {{! result column }}
+                <p>{{localize "SAS-TRADING.trade-menu.gather-info.results.content"}}</p>
+                {{#if gatherInfoResult.accurate}}
+                    <p class="sas-menu-results-gather-info-success">{{localize "SAS-TRADING.trade-menu.gather-info.results.success"}}</p>
+                {{else}}
+                    <p class="sas-menu-results-gather-info-failure">{{localize "SAS-TRADING.trade-menu.gather-info.results.failure"}}</p>
+                {{/if}}
+            </div>
+            <div class="flexcol">
+                {{! numbers column }}
+                <div class="flexrow">
+                    <div class="flexcol">
+                        {{! labels column }}
+                        <p>{{localize "SAS-TRADING.good"}}:</p>
+                        <p>{{localize "SAS-TRADING.trade-menu.gather-info.results.accuracy-thresh"}} </p>
+                        <p>{{localize "SAS-TRADING.trade-menu.gather-info.results.accuracy-roll"}} </p>
+                    </div>
+                    <div class="flexcol">
+                        {{! values column}}
+                        <p>{{gatherInfoResult.good}}</p>
+                        <div class="flexrow">
+                            <p>{{gatherInfoResult.accuracyThresh}}</p>
+                            <p>=</p>
+                            <p title="{{localize "SAS-TRADING.trade-menu.gather-info.results.accuracy-base-title"}}">
+                                {{gatherInfoResult.baseAccuracy}}
+                            </p>
+                            <p>+</p>
+                            <p title="{{localize "SAS-TRADING.trade-menu.gather-info.results.diplo-roll-title"}}">
+                                {{gatherInfoResult.diplomacyRoll}}
+                            </p>
+                            <p>-</p>
+                            <p title="{{localize "SAS-TRADING.trade-menu.gather-info.results.diplo-dc-title"}}">
+                                {{gatherInfoResult.diploDc}}
+                            </p>
+                        </div>
+                        <p>{{gatherInfoResult.accuracyRoll}}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {{/if}}
     <button type="button" class="sas-menu-button" data-action="gatherInfo-roll">
         <i class="fas fa-dice-d20"></i>{{localize "SAS-TRADING.trade-menu.gather-info.roll-accuracy"}}
     </button>


### PR DESCRIPTION
Add gather info results directly to the trading menu instead of opening a dialog. This seems less intrusive and requires fewer clicks.