### PR TITLE
Add missing download link in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,6 +19,7 @@
     "bugs": "https://github.com/MichaelJBradley/foundry-vtt-trading-module/issues",
     "url": "https://github.com/MichaelJBradley/foundry-vtt-trading-module",
     "manifest": "https://github.com/MichaelJBradley/foundry-vtt-trading-module/releases/latest/download/module.json",
+    "download": "https://github.com/MichaelJBradley/foundry-vtt-trading-module/releases/latest/download/module.zip",
     "scripts": [
         "scripts/sas-trading.js"
     ],


### PR DESCRIPTION
Foundry could not install from the latest release's module.json because it did not include the download link.

The action also didn't replace the `manifest` or add the `download` properties, but this may have been because `download` was missing.