### PR TITLE
Make variable content scrollable

### DIFF
--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -591,6 +591,7 @@ class SasTradingGoodConfig extends FormApplication {
             closeOnSubmit: false,
             submitOnChange: true,
             resizable: true,
+            scrollY: ['[save-scroll-existing=true]', '[save-scroll-new=true]'],
             selectedCity: SasTradingCitiesData.allCitiesSorted[0],
             newGoods: {},
         }
@@ -723,6 +724,7 @@ class SasTradingBaseGoodConfig extends FormApplication {
             closeOnSubmit: false,
             submitOnChange: true,
             resizable: true,
+            scrollY: ['[save-scroll-existing=true]', '[save-scroll-new=true]'],
             newGoods: {}
         }
         const mergedOptions = foundry.utils.mergeObject(defaults, overrides)
@@ -844,6 +846,7 @@ class SasTradingCitiesConfig extends FormApplication {
             closeOnSubmit: false,
             submitOnChange: true,
             resizable: true,
+            scrollY: ['[save-scroll-existing=true]', '[save-scroll-new=true]'],
             newCities: {}
         }
         const mergedOptions = foundry.utils.mergeObject(defaults, overrides)

--- a/styles/sas-trading.css
+++ b/styles/sas-trading.css
@@ -2,6 +2,15 @@
     padding: 0;
     margin-top: 0;
     gap: 1em;
+
+    max-height: 210px;
+    overflow-y: scroll;
+    scrollbar-width: thin;
+    -ms-overflow-style: auto;
+}
+
+.sas-config::-webkit-scrollbar {
+    display: auto;
 }
 
 .sas-config > li {
@@ -61,6 +70,17 @@
 
 .sas-menu-content {
     margin-top: 10px;
+}
+
+.sas-menu-overview-table {
+    max-height: 160px;
+    overflow-y: scroll;
+    scrollbar-width: thin;
+    -ms-overflow-style: auto;
+}
+
+.sas-menu-overview-table::-webkit-scrollbar {
+    display: auto;
 }
 
 .sas-menu-results {

--- a/templates/sas-base-goods-config.hbs
+++ b/templates/sas-base-goods-config.hbs
@@ -1,6 +1,6 @@
 <form>
     <p class="sas-config-header">{{localize "SAS-TRADING.total-goods"}} {{numBaseGoods}}</p>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-existing="true">
         {{#each baseGoods as | baseGood |}}
             <li class="flexrow" data-base-good-name="{{baseGood.name}}">
                 <p class="flex2"><b>{{baseGood.name}}</b></p>
@@ -14,7 +14,7 @@
             {{localize "SAS-TRADING.settings.config.base-goods-menu.missing-goods"}}
         {{/each}}
     </ul>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-new="true">
         {{#each newGoods as | newGood |}}
             <li class="flexrow" data-new-good-id="{{newGood.id}}">
                 <p class="flex0">{{localize "SAS-TRADING.name"}}</p>

--- a/templates/sas-cities-config.hbs
+++ b/templates/sas-cities-config.hbs
@@ -1,5 +1,5 @@
 <form>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-existing="true">
         {{#each cities as | city |}}
             <li class="flexrow" data-city-name="{{this}}">
                 <p name="existing.{{this}}"><b>{{this}}</b></p>
@@ -11,7 +11,7 @@
             {{localize "SAS-TRADING.settings.config.cities-menu.missing-cities"}}
         {{/each}}
     </ul>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-new="true">
         {{#each newCities as | newCity |}}
             <li class="flexrow" data-new-city-id="{{newCity.id}}">
                 <input type="text" value="{{newCity.name}}" name="new.{{newCity.id}}.name" data-dtype="String" />

--- a/templates/sas-goods-config.hbs
+++ b/templates/sas-goods-config.hbs
@@ -13,7 +13,7 @@
             <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
         </div>
     </div>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-existing="true">
         {{#each goodsByCity as | good |}}
             <li class="flexrow" data-good-id="{{good.id}}">
                 <p><b>{{good.name}}</b></p>
@@ -42,7 +42,7 @@
             {{localize "SAS-TRADING.settings.config.goods-menu.missing-goods"}}
         {{/each}}
     </ul>
-    <ul class="sas-config flexcol">
+    <ul class="sas-config flexcol" save-scroll-new="true">
         {{#each newGoods as | newGood | }}
             <li class="flexrow" data-good-id="{{newGood.id}}" data-good-city="{{../selectedCity}}">
                 <input type="text" value="{{newGood.name}}" name="new.{{newGood.id}}.name" data-dtype="String" />

--- a/templates/sas-trading-menu-overview.hbs
+++ b/templates/sas-trading-menu-overview.hbs
@@ -12,25 +12,27 @@
         <p class="flex1">{{localize "SAS-TRADING.total-goods"}} {{numGoods}}</p>
     </div>
 </div>
-<table>
-    <tr>
-        <th>{{localize "SAS-TRADING.good"}}</th>
-        <th>{{localize "SAS-TRADING.value"}}</th>
-        <th>{{localize "SAS-TRADING.demand"}}</th>
-        <th>{{localize "SAS-TRADING.scarcity"}}</th>
-    </tr>
-    {{#each goodsByCity as | good | }}
+<div class="sas-menu-overview-table">
+    <table>
         <tr>
-            <td class="sas-menu-table-data">{{good.name}}</td>
-            <td class="sas-menu-table-data">{{good.value}}</td>
-            <td class="sas-menu-table-data">{{good.demand}}</td>
-            <td class="sas-menu-table-data">{{good.scarcity}}</td>
+            <th>{{localize "SAS-TRADING.good"}}</th>
+            <th>{{localize "SAS-TRADING.value"}}</th>
+            <th>{{localize "SAS-TRADING.demand"}}</th>
+            <th>{{localize "SAS-TRADING.scarcity"}}</th>
         </tr>
-    {{else}}
-        <tr>
-            <td colspan="4" class="sas-menu-table-data">
-                {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
-            </td> 
-        </tr>
-    {{/each}}
-</table>
+        {{#each goodsByCity as | good | }}
+            <tr>
+                <td class="sas-menu-table-data">{{good.name}}</td>
+                <td class="sas-menu-table-data">{{good.value}}</td>
+                <td class="sas-menu-table-data">{{good.demand}}</td>
+                <td class="sas-menu-table-data">{{good.scarcity}}</td>
+            </tr>
+        {{else}}
+            <tr>
+                <td colspan="4" class="sas-menu-table-data">
+                    {{localize "SAS-TRADING.trade-menu.overview.missing-goods"}}
+                </td> 
+            </tr>
+        {{/each}}
+    </table>
+</div>


### PR DESCRIPTION
The FormApplications' heights were set to auto, which meant when there were too many trade goods or cities, the application would expand to the entire screen before auto scaling.

To ensure buttons and headers remain visible, as well as let the trading menu auto expand for results, the tables and lists were given a max height and made scrollable.

**Note:** This was only tested in Firefox, so it might cause issues in other browsers or the Foundry app