### PR TITLE
Generate demand/scarcity on failed gather info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Error and warning notification on invalid input throughout the module
+* Display trade good's demand and scarcity in gather info results
+* Generate random demand and scarcity pair on failed gather info results
+
+### Fixed
+
+* Typo in gather info results
+
 ## [0.3.0]
 
 ### Fixed

--- a/languages/en.json
+++ b/languages/en.json
@@ -79,7 +79,7 @@
                     "title": "Gather rumors results",
                     "content": "The rumors were",
                     "success": "ACCURATE",
-                    "failure": "INNACCURATE",
+                    "failure": "INACCURATE",
                     "accuracy-thresh": "Accuracy threshold:",
                     "accuracy-roll": "Accuracy roll:",
                     "accuracy-base-title": "Base DC for accuracy roll",

--- a/templates/sas-trading-menu-gather-info.hbs
+++ b/templates/sas-trading-menu-gather-info.hbs
@@ -83,12 +83,14 @@
                     <div class="flexcol">
                         {{! labels column }}
                         <p>{{localize "SAS-TRADING.good"}}:</p>
+                        <p>{{localize "SAS-TRADING.demand"}}, {{localize "SAS-TRADING.scarcity"}}</p>
                         <p>{{localize "SAS-TRADING.trade-menu.gather-info.results.accuracy-thresh"}} </p>
                         <p>{{localize "SAS-TRADING.trade-menu.gather-info.results.accuracy-roll"}} </p>
                     </div>
                     <div class="flexcol">
                         {{! values column}}
                         <p>{{gatherInfoResult.good}}</p>
+                        <p>{{capitalize gatherInfoResult.demand}}, {{capitalize gatherInfoResult.scarcity}}</p>
                         <div class="flexrow">
                             <p>{{gatherInfoResult.accuracyThresh}}</p>
                             <p>=</p>


### PR DESCRIPTION
Generate a random demand and scarcity pair on a failed gather info check
* Randomly selecting a demand and scarcity on a failed gather info check makes it easier on the GM and more fair for players.

Display demand and scarcity in gather info results

Fix empty console warnings

Fix typo in gather info results: "innaccurate"

Close #27 