### PR TITLE
Fix auto create missing demand and scaricity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Using auto create to configure in trade goods for a city preventing the trade menu from opening
+
 ## [1.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Using auto create to configure in trade goods for a city preventing the trade menu from opening
+* Auto create trade goods for a city preventing the trade menu from opening
 
 ## [1.0.0]
 

--- a/scripts/sas-trading.js
+++ b/scripts/sas-trading.js
@@ -375,7 +375,7 @@ class SasTradingGoodData {
         if (!good.id) {
             good.id = this.goodId(good.name, good.city)
         } else if (good.id !== this.goodId(good.name, good.city)) {
-            SasTrading.error(false, 'good.id "', good.id, '" does not match expected id:', this.goodId(good.name, good.city))
+            SasTrading.error('good.id "', good.id, '" does not match expected id:', this.goodId(good.name, good.city))
             return
         }
 
@@ -401,13 +401,13 @@ class SasTradingGoodData {
     static createGoods(goods) {
         const goodsData = Object.fromEntries(goods.map(good => {
             if (!good.name || !good.city) {
-                SasTrading.error(false, 'good must have at least name and city properties', good)
+                SasTrading.error('good must have at least name and city properties', good)
                 return
             }
             if (!good.id) {
                 good.id = this.goodId(good.name, good.city)
             } else if (good.id !== this.goodId(good.name, good.city)) {
-                SasTrading.error(false, 'good.id "', good.id, '" does not match expected id:', this.goodId(good.name, good.city))
+                SasTrading.error('good.id "', good.id, '" does not match expected id:', this.goodId(good.name, good.city))
                 return
             }
 
@@ -770,6 +770,8 @@ class SasTradingGoodConfig extends FormApplication {
                     return {
                         name: baseGood.name,
                         city: autoCreateSelectedCity,
+                        demand: SasTradingGoodData.demand.HIGH,
+                        scarcity: SasTradingGoodData.scarcity.RARE
                     }
                 })
                 SasTradingGoodData.createGoods(autoCreatedGoods)


### PR DESCRIPTION
Auto creating goods without actually updating any fields would cause the trading menu to break.

This fixes the breakage by setting default demand and scarcity values so that they don't start undefined.

There's still a possibility that this could break if creating a new good and not updating fields, but that will be fixed in a later change.

Also fix console errors including a `false` 

Close #41 